### PR TITLE
ci: use forked netlify cli action

### DIFF
--- a/.github/workflows/build-and-deploy-studio.yml
+++ b/.github/workflows/build-and-deploy-studio.yml
@@ -31,7 +31,7 @@ jobs:
       - run: cp netlify.toml dist/netlify.toml
         working-directory: ./studio
       - name: Publish
-        uses: netlify/actions/cli@master
+        uses: jaska120/netlify-actions/cli@master
         with:
           args: deploy --dir=studio/dist --prod
         env:

--- a/.github/workflows/build-and-deploy-web.yml
+++ b/.github/workflows/build-and-deploy-web.yml
@@ -30,7 +30,7 @@ jobs:
       - run: NODE_OPTIONS=--max-old-space-size=8192 yarn build
         working-directory: ./web
       - name: Publish
-        uses: netlify/actions/cli@master
+        uses: jaska120/netlify-actions/cli@master
         with:
           args: deploy --dir=web/public --prod
         env:


### PR DESCRIPTION
Tämän pitäisi korjata buildi, joka on raportoitu jo https://github.com/netlify/actions/issues/60. Forkkasin netlify actionin ja bumppasin node 12 -> 14 https://github.com/jaska120/netlify-actions/commit/2a821f0d0807df74bc8660bacd382051e3cfc672. En ole koskaan ennen forkannut github actionia, niin ei ole mitään takeita toiminnasta. Toki tämän pystyy reverttaamaan hyvin yksinkertaisesti tarvittaessa. :)